### PR TITLE
  fix: 緯度経度のハッシュキー（hkey）生成時における浮動小数点の丸め誤差を修正

### DIFF
--- a/scripts/csv2redis.py
+++ b/scripts/csv2redis.py
@@ -4,6 +4,7 @@
 
 import sys
 from io import BytesIO
+from decimal import Decimal, ROUND_HALF_UP, ROUND_HALF_EVEN
 import csv
 import codecs
 from xml.dom import minidom
@@ -1233,7 +1234,7 @@ class Csv2redisClass():
       if i!= latCol and i!= lngCol:
         meta.append(data)
 
-    hkey = str(math.floor(lat * 100000)) + ":" + str(math.floor(lng * 100000)) + ":" + ",".join(meta)
+    hkey = str(int(Decimal(lat * 100000).quantize(Decimal('0.1')))) + ":" + str(int(Decimal(lng * 100000).quantize(Decimal('0.1')))) + ":" + ",".join(meta)
     ans = {"lat":lat,"lng":lng,"hkey":hkey}
     return ans
 

--- a/tests/test_character_patterns.py
+++ b/tests/test_character_patterns.py
@@ -1,0 +1,92 @@
+import unittest
+import fakeredis
+import math
+import sys
+import os
+
+# プロジェクトルートをパスに追加
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from scripts.csv2redis import Csv2redisClass
+
+class TestSpecialCharacterPatterns(unittest.TestCase):
+    def setUp(self):
+        # Redisのモックを作成
+        self.f_redis = fakeredis.FakeStrictRedis(version=6)
+        self.c2r = Csv2redisClass()
+        self.c2r.set_connect(self.f_redis)
+        self.c2r.init("test_special:")
+        
+        # テスト用のスキーマ設定（id, name, latitude, longitude, note）
+        self.c2r.schemaObj = {
+            'schema': ['id', 'name', 'latitude', 'longitude', 'note'],
+            'type': [Csv2redisClass.T_STR, Csv2redisClass.T_STR, Csv2redisClass.T_NUMB, Csv2redisClass.T_NUMB, Csv2redisClass.T_STR],
+            'latCol': 2,
+            'lngCol': 3,
+            'titleCol': 1,
+            'idCol': -1,
+            'namespace': 'test_special:',
+            'name': 'test_layer'
+        }
+
+    def tearDown(self):
+        self.f_redis.close()
+
+    def run_add_delete_test(self, test_data_list):
+        """登録して削除できるかの一連の流れをテストするヘルパー"""
+        max_level = 16
+        # 1. 登録
+        reg_result = self.c2r.burstRegistData(test_data_list, max_level)
+        self.assertGreaterEqual(reg_result['success'], 1, "登録に失敗しました")
+        
+        # 2. 削除
+        del_result_dict = self.c2r.burstDeleteData(test_data_list, max_level)
+        # 削除成功数を確認
+        self.assertEqual(del_result_dict["success"], len(test_data_list), f"削除に失敗しました。戻り値: {del_result_dict}")
+
+    def test_half_width_pattern(self):
+        """半角英数字のパターン"""
+        data = [{
+            'lat': 35.0, 'lng': 135.0,
+            'hkey': '3500000:13500000:ID001,AlphaName,Note1',
+            'data': 'ID001,AlphaName,35.0,135.0,Note1'
+        }]
+        self.run_add_delete_test(data)
+
+    def test_full_width_pattern(self):
+        """全角日本語のパターン"""
+        data = [{
+            'lat': 35.1, 'lng': 135.1,
+            'hkey': '3510000:13510000:ID002,日本語名,備考データ',
+            'data': 'ID002,日本語名,35.1,135.1,備考データ'
+        }]
+        self.run_add_delete_test(data)
+
+    def test_full_width_hyphen(self):
+        """全角ハイフンのパターン"""
+        data = [{
+            'lat': 35.3, 'lng': 135.3,
+            'hkey': '3530000:13530000:ID－004,ハイフン－あり,備考－全角',
+            'data': 'ID－004,ハイフン－あり,35.3,135.3,備考－全角'
+        }]
+        self.run_add_delete_test(data)
+
+    def test_full_width_space(self):
+        """全角スペースのパターン"""
+        data = [{
+            'lat': 35.4, 'lng': 135.4,
+            'hkey': '3540000:13540000:ID005,名称　太郎,備考　全角スペース',
+            'data': 'ID005,名称　太郎,35.4,135.4,備考　全角スペース'
+        }]
+        self.run_add_delete_test(data)
+
+    def test_full_width_symbols(self):
+        """全角記号（カンマ、コロン）のパターン"""
+        data = [{
+            'lat': 35.2, 'lng': 135.2,
+            'hkey': '3520000:13520000:ID003,名称：テスト,備考，カンマあり',
+            'data': 'ID003,名称：テスト,35.2,135.2,備考，カンマあり'
+        }]
+        self.run_add_delete_test(data)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_csv2redis.py
+++ b/tests/test_csv2redis.py
@@ -120,6 +120,18 @@ class TestOfCsv2Redis(unittest.TestCase):
 
     self.assertEqual(result, correct)
 
+  def test_rounding_error_patterns(self):
+    schema = [0, 2, 2, 0, 1, 1, 1, 1, 0]
+    # 33.12（5桁未満）で丸め誤差（3312000ではなく3311999になる）のケース
+    data = ['jp','a','A','47','','33.12','139.76712','33.12','okinawa']
+    result = self.c2r.getPoiKey(data, 5, 6, schema)
+    self.assertTrue(result['hkey'].startswith('3312000:13976712:'))
+    
+    # 32.00017（5桁）で丸め誤差（3200017ではなく3200016になる）のケース
+    data = ['jp','a','A','47','','32.00017','139.76712','32.00017','okinawa']
+    result = self.c2r.getPoiKey(data, 5, 6, schema)
+    self.assertTrue(result['hkey'].startswith('3200017:13976712:'))
+    
   @patch("pickle.loads", MagicMock(side_effect=Exception()))
   def test_saveSvgMapTileN_throwException(self):
     self.c2r.schemaObj = {


### PR DESCRIPTION
  ## 概要

  緯度経度からRedis用のハッシュキー（ hkey ）を生成する際、浮動小数点の演算に伴う丸め誤差によって想定より1小さい数値でキーが生成されてしまうバグを修正した。
また、本修正に伴う丸め誤差パターンのテストの追加、および調査中に試験した特殊文字パターンの新規テストを追加しました。

  ## 背景・修正理由

  Pythonの浮動小数点数の特性上、例えば  33.12 * 100000  は内部的に  3311999.9999999995  のように表現されます。
  従来のコードでは  math.floor(lat * 100000)  を使用していたため、この値が切り捨てられて  3311999  となり、本来期待されるハッシュキー  3312000  からずれてしまう不整合が生じていました。

  この問題を解決するため、 Decimal  モジュールを導入し、値を高精度で計算した後に四捨五入（ quantize(Decimal('0.1')) ）を行うことで、微小な浮動小数点誤差を正しく丸めてから整数化する実装に変更しました。

  ## 変更内容

  ### 1. メインロジックの修正

  • csv2redis.py の  csv2redis.py  メソッド
      •  math.floor  を用いた切り捨て処理から、 Decimal  を用いた丸め処理へ変更し、意図した通りのハッシュキーが生成されるように修正しました。


  ### 2. テストコードの追加

  • 既存テストへの追加: test_csv2redis.py
      • 丸め誤差が発生しやすい具体的な緯度の値（ 33.12  および  32.00017 ）を検証するテストケース  test_csv2redis.py  を追加しました。
  • 新規テストファイルの作成: test_character_patterns.py
      • 全角・半角、スペース、ハイフン、全角記号などの特殊文字パターンを含むデータに対して、Redisへの一括登録・一括削除が正常に動作することを検証するテストクラス  test_character_patterns.py  を新規追加しました。
